### PR TITLE
Add gitignore rules for IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE
+.idea
+.vscode


### PR DESCRIPTION
Add rules to ignore workspace directory of some IDEs: PyCharm(`.idea`) and Visual Studio Code(`.vscode`).