### PR TITLE
Remove Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - "3.6"
-
-install:
-  - pip install pytest
-
-script:
-  - pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Git Sample
 
-[![Build Status](https://travis-ci.org/dal-lab/git-sample.svg?branch=master)](https://travis-ci.org/dal-lab/git-sample)
 [![works badge](https://cdn.jsdelivr.net/gh/nikku/works-on-my-machine@v0.2.0/badge.svg)](https://github.com/nikku/works-on-my-machine)
 
 This repository is a playground to learn Git.


### PR DESCRIPTION
Remove Travis CI configuration due to discontinuation of free suuport.

Delete the `.travis.yml` file and remove the badge from `README.md` file.